### PR TITLE
Add tests for times and utility components

### DIFF
--- a/src/TimesAndUtils.test.tsx
+++ b/src/TimesAndUtils.test.tsx
@@ -1,0 +1,54 @@
+import times from "./components/weekly-time-scheduler/times";
+import { hasIntersection } from "./components/weekly-time-scheduler/utility";
+
+describe("Times component", () => {
+  test("should contain 48 time slots", () => {
+    expect(times.length).toBe(48);
+  });
+
+  test("should start with 12 AM", () => {
+    expect(times[0]).toBe("12 AM");
+  });
+
+  test("should end with 12 AM", () => {
+    expect(times[times.length - 1]).toBe("12 AM");
+  });
+});
+
+describe("Utils component", () => {
+  test("should return true for intersecting spans", () => {
+    const spans: [number, number][] = [
+      [0, 5],
+      [4, 10],
+      [9, 15],
+    ];
+    expect(hasIntersection(spans)).toBe(true);
+  });
+
+  test("should return false for non-intersecting spans", () => {
+    const spans: [number, number][] = [
+      [0, 5],
+      [6, 10],
+      [11, 15],
+    ];
+    expect(hasIntersection(spans)).toBe(false);
+  });
+
+  test("should return true for partially overlapping spans", () => {
+    const spans: [number, number][] = [
+      [0, 5],
+      [5, 10],
+      [9, 15],
+    ];
+    expect(hasIntersection(spans)).toBe(true);
+  });
+
+  test("should return true for identical spans", () => {
+    const spans: [number, number][] = [
+      [0, 5],
+      [0, 5],
+      [0, 5],
+    ];
+    expect(hasIntersection(spans)).toBe(true);
+  });
+});


### PR DESCRIPTION
This PR adds Jest tests for the Times and Utils components. 

The test for the Times component ensures that the times array contains exactly 48 time slots. 

The test for the Utils component checks the hasIntersection function, which is used in other parts of the project.

Do keep in mind though, it's a starting point, not final version.